### PR TITLE
Configurable playbook filenames per VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Initially, two hosts are defined as an example: `srv001` and `srv002`. If you wa
 - name: srv005
   ip: 192.168.56.14
   mac: "00:03:DE:AD:BE:EF"
+  playbook: server.yml  # defaults to site.yml
 ```
 
 - `site.yml` to assign roles to your nodes, e.g.:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ hosts = YAML.load_file('vagrant-hosts.yml')
 
 # {{{ Helper functions
 
-def provision_ansible(config)
+def provision_ansible(config, host)
   if run_locally?
     # Provisioning configuration for shell script.
     config.vm.provision 'shell' do |sh|
@@ -31,7 +31,9 @@ def provision_ansible(config)
   else
     # Provisioning configuration for Ansible (for Mac/Linux hosts).
     config.vm.provision 'ansible' do |ansible|
-      ansible.playbook = 'ansible/site.yml'
+      ansible.playbook = host.key?('playbook') ?
+          "ansible/#{host['playbook']}" :
+          "ansible/site.yml"
       ansible.sudo = true
     end
   end
@@ -96,9 +98,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # host name, this will fail.
         vb.customize ['modifyvm', :id, '--groups', PROJECT_NAME]
       end
+      provision_ansible(config, host)
     end
   end
-  provision_ansible(config)
 end
 
 # -*- mode: ruby -*-


### PR DESCRIPTION
I have a setup with many VMs, that fall into the categories of either "server" or "client". Perhaps there's a simpler way on the Ansible side to handle this, but I added an optional `playbook:` key to handle different playbook filenames.

Example:
```
# vagrant-hosts.yml
---
- name: ubuntu
  box: bento/ubuntu-16.04
  playbook: server.yml

- name: mac
  box: codesmith/macos-10.12.1
  playbook: client.yml
```

The above configuration uses `ansible/server.yml` and `ansible/client.yml` files for the Ansible provisioning. If the `playbook:` key is not provided, it defaults to `ansible/site.yml` as before.

I'm fairly new to Ansible, so if there is a cleaner way to do this, just let me know. Thanks for making this public! It's helping me immensely.