### PR TITLE
Add dynamic vagrant hosts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,15 @@ Initially, two hosts are defined as an example: `srv001` and `srv002`. If you wa
 ## Run with custom vagrant-hosts file
 
 ```ShellSession
-VAGRANTS_HOST=='custom-vagrant-hosts.yml' vagrant up
+VAGRANTS_HOST='custom-vagrant-hosts.yml' vagrant up
 ```
 or
 
 ```ShellSession
 # for Linux
-export VAGRANTS_HOST=='custom-vagrant-hosts.yml'
+export VAGRANTS_HOST='custom-vagrant-hosts.yml'
 vagrant up
 ```
-
 
 ## Running tests with BATS
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ You can either clone this project or use the provided initialization script.
 When cloning, choose another name for the target directory!
 
 ```ShellSession
-$ git clone https://github.com/bertvv/ansible-skeleton.git my-ansible-project
+> git clone https://github.com/bertvv/ansible-skeleton.git my-ansible-project
 ```
 
 On Windows, it is important to keep line endings in the Linux format:
 
 ```ShellSession
-$ git clone --config core.autocrlf=input https://github.com/bertvv/ansible-skeleton.git my-ansible-project
+> git clone --config core.autocrlf=input https://github.com/bertvv/ansible-skeleton.git my-ansible-project
 ```
 
 After cloning, it's best to remove the `.git` directory and initialise a new repository. The history of the skeleton code is irrelevant for your Ansible project...
@@ -39,13 +39,13 @@ After cloning, it's best to remove the `.git` directory and initialise a new rep
 You can find an [initialization script](https://github.com/bertvv/ansible-toolbox/blob/master/bin/atb-init.sh) in my [ansible-toolbox](https://github.com/bertvv/ansible-toolbox/) that automates the process (including creating an empty Git repository).
 
 ```ShellSession
-$ atb-init my-ansible-project
+> atb-init my-ansible-project
 ```
 
 This will download the latest version of the skeleton from Github, initialize a Git repository, do the first commit, and, optionally, install any specified role.
 
 ```ShellSession
-$ atb-init my-ansible-project bertvv.el7 bertvv.httpd
+> atb-init my-ansible-project bertvv.el7 bertvv.httpd
 ```
 
 This will create the skeleton and install roles `bertvv.el7` and `bertvv.httpd` from Ansible Galaxy.
@@ -53,7 +53,6 @@ This will create the skeleton and install roles `bertvv.el7` and `bertvv.httpd` 
 ## Getting started
 
 First, modify the `Vagrantfile` to select your favourite base box. I use a CentOS 7 base box, based on [Mischa Taylor's Packer template](https://github.com/boxcutter/centos). This is probably the only time you need to edit the `Vagrantfile`.
-
 
 The `vagrant-hosts.yml` file specifies the nodes that are controlled by Vagrant. You should at least specify a `name:`, other settings (see below) are optional. A host-only adapter is created and the given IP assigned to that interface. Other optional settings that can be specified:
 
@@ -112,6 +111,20 @@ Initially, two hosts are defined as an example: `srv001` and `srv002`. If you wa
     - bertvv.httpd
 ```
 
+## Run with custom vagrant-hosts file
+
+```ShellSession
+VAGRANTS_HOST=='custom-vagrant-hosts.yml' vagrant up
+```
+or
+
+```ShellSession
+# for Linux
+export VAGRANTS_HOST=='custom-vagrant-hosts.yml'
+vagrant up
+```
+
+
 ## Running tests with BATS
 
 There's a discussion on whether Unit tests are necessary for Ansible. Indeed, with its declarative nature, Ansible largely takes away the need to check for certain things independently from the playbook definitions. For a bit more background, be sure to read through [this discussion unit testing for Ansible](https://groups.google.com/forum/#!topic/ansible-project/7VhqDDtf6Js) on Google groups.
@@ -120,15 +133,15 @@ However, it is my opinion that playbooks don't cover everything (e.g. whether a 
 
 Put your BATS test scripts in the `test/` directory and they will become available on your guest VMs as a synced folder, mounted in `/vagrant/test`. Scripts that you want to run on each host should be stored in the `test/` directory itself, scripts for individual hosts should be stored in subdirectories with the same name as the host (see example below). Inside the VM, run
 
-```
-sudo /vagrant/test/runbats.sh
+```ShellSession
+> sudo /vagrant/test/runbats.sh
 ```
 
 to execute all tests relevant for that host. The script will install BATS if needed.
 
 Suppose the `test/` directory is structured like the example below:
 
-```
+```ShellSession
 test/
 ├── common.bats
 ├── runbats.sh
@@ -140,13 +153,12 @@ test/
 
 On host `srv001`, the scripts `common.bats` and `web.bats` will be executed, on host `srv002`, it's `common.bats` and `db.bats`.
 
-
 ## Acknowledgements
 
 The Windows bootstrap script is based on the MIT licensed work of:
 
-- Kawsar Saiyeed: https://github.com/KSid/windows-vagrant-ansible
-- Jeff Geerling: https://github.com/geerlingguy/JJG-Ansible-Windows
+- [Kawsar Saiyeed](https://github.com/KSid/windows-vagrant-ansible)
+- [Jeff Geerling]( https://github.com/geerlingguy/JJG-Ansible-Windows)
 
 ## Contributors
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,9 @@
 require 'rbconfig'
 require 'yaml'
 
+# set default LC_ALL for all BOXES
+ENV["LC_ALL"] = "en_US.UTF-8"
+
 # Set your default base box here
 DEFAULT_BASE_BOX = 'bento/centos-7.4'
 
@@ -18,7 +21,9 @@ PROJECT_NAME = '/' + File.basename(Dir.getwd)
 # instead of from the host machine (provided Ansible is installed).
 FORCE_LOCAL_RUN = false
 
-hosts = YAML.load_file('vagrant-hosts.yml')
+# set custom vagrant-hosts file
+vagranthosts = ENV['VAGRANTS_HOST'] ? ENV['VAGRANTS_HOST'] : 'vagrant-hosts.yml'
+hosts = YAML.load_file(File.join(__dir__, vagranthosts))
 
 # {{{ Helper functions
 

--- a/custom-vagrant-hosts.yml
+++ b/custom-vagrant-hosts.yml
@@ -1,0 +1,42 @@
+# Vagrantfile file for create primary server with 1..n siebling server for simulate cloud enviroment
+
+
+# vagrant_hosts.yml
+#
+# List of hosts to be created by Vagrant. This file controls the Vagrant
+# settings, specifically host name and network settings. You should at least
+# have a `name:`.  Other optional settings that can be specified:
+#
+# * `ip`: by default, an IP will be assigned by DHCP. If you want a fixed
+#         addres, specify it.
+# * `netmask`: by default, the network mask is `255.255.255.0`. If you want
+#              another one, it should be specified.
+# * `mac`: The MAC address to be assigned to the NIC. Several notations are
+#          accepted, including "Linux-style" (`00:11:22:33:44:55`) and
+#          "Windows-style" (`00-11-22-33-44-55`). The separator characters can
+#          be omitted altogether (`001122334455`).
+# * `intnet`: If set to `true`, the network interface will be attached to an
+#             internal network rather than a host-only adapter.
+# * `forwarded_ports`: A list of forwarded ports. Required items are `host` and 'guest`
+# * `auto_config`: If set to `false`, Vagrant will not attempt to configure
+#                  the network interface.
+# * `shell_always`: a list of shell scripts to be run after boot of the
+#                   machine. Required field is `cmd` having the path
+# * `synced_folders`: A list of dicts that specify synced folders. `src` and
+#   `dest` are mandatory, `options:` are optional. For the possible options,
+#   see the Vagrant documentation[1]. Keys of options should be prefixed with
+#   a colon, e.g. `:owner:`.
+#
+# To enable *provisioning*, add these hosts to site.yml and assign some roles.
+#
+# [1] http://docs.vagrantup.com/v2/synced-folders/basic_usage.html
+---
+- name: primary
+  box: debian/stretch64
+  
+
+- name: worker
+  box: debian/stretch64
+  
+
+


### PR DESCRIPTION
Hallo Bert,
BTW your project is a great idea.
I add the possibility to used custom vagrant-hosts files, so i must not clone that project and delete the .git directory. I can hold the structure of the project.

I'm add the sample script custom-vagrant-host.yaml and add a description in the README.md  file.

I fix same github markdown issue follow these rules https://github.com/DavidAnson/markdownlint/blob/v0.6.4/doc/Rules.md 

Mathias


