### PR TITLE
Put ansible provision step in a function again

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,6 +118,20 @@ end
 
 # }}}
 
+def provision_ansible(node, host, groups)
+  ansible_mode = run_locally? ? 'ansible_local' : 'ansible'
+  node.vm.provision ansible_mode do |ansible|
+    ansible.compatibility_mode = '2.0'
+    if ! groups.nil?
+      ansible.groups = groups
+    end
+    ansible.playbook = host.key?('playbook') ?
+        "ansible/#{host['playbook']}" :
+        "ansible/site.yml"
+    ansible.become = true
+  end
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.insert_key = false
   hosts.each do |host|
@@ -142,17 +156,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       # Ansible provisioning
-      ansible_mode = run_locally? ? 'ansible_local' : 'ansible'
-      node.vm.provision ansible_mode do |ansible|
-        ansible.compatibility_mode = '2.0'
-        if ! groups.nil?
-          ansible.groups = groups
-        end
-        ansible.playbook = host.key?('playbook') ?
-            "ansible/#{host['playbook']}" :
-            "ansible/site.yml"
-        ansible.become = true
-      end
+      provision_ansible(node, host, groups)
     end
   end
 end


### PR DESCRIPTION
Put the provision step back into a function, as it was before 1d86b78a99ba7b3333033c9604653ab56ad4b902. Ansible playbooks still only run once, which was the intention of 1d86b78a99ba7b3333033c9604653ab56ad4b902.